### PR TITLE
Allow creating root objects with specific ids

### DIFF
--- a/adapters/InMemoryObjectRepository.js
+++ b/adapters/InMemoryObjectRepository.js
@@ -3,12 +3,16 @@ const ObjectRepository = require('../domain/ObjectRepository')
 const ObjectFactory = require('../domain/StatefulObject.factory')
 const IdGenerator = require('./InMemoryIdGenerator')
 
-module.exports = function() {
-    let repository = ObjectRepository({factory: ObjectFactory(), idGenerator: IdGenerator(), state: State()})
+module.exports = function(dependencies) {
+    let repository = ObjectRepository({
+        factory: ObjectFactory(),
+        idGenerator: (dependencies && dependencies.idGenerator) || IdGenerator(),
+        state: State()})
 
     return Object.freeze({
         getNew,
-        get
+        get,
+        getRoot
     })
 
     async function getNew(){
@@ -19,4 +23,7 @@ module.exports = function() {
         return repository.get(id)
     }
 
+    async function getRoot(id){
+        return repository.getRoot(id)
+    }
 }

--- a/domain/ObjectRepository.js
+++ b/domain/ObjectRepository.js
@@ -1,13 +1,20 @@
 module.exports = function({factory, idGenerator, state}) {
     return Object.freeze({
         getNew,
-        get
+        get,
+        getRoot
     })
+
+    async function getRoot(id){
+        var internalId = `root-${id}`
+        return await factory.create({id: internalId, state, objectRepository: this})
+    }
 
     async function getNew(){
         let id = await idGenerator.getNew()
-        await state.register(id)
-        return await factory.create({id, state, objectRepository: this})
+        var internalId = `internal-${id}`
+        await state.register(internalId)
+        return await factory.create({id: internalId, state, objectRepository: this})
     }
 
     async function get(id){

--- a/domain/ObjectRepository.spec.js
+++ b/domain/ObjectRepository.spec.js
@@ -21,12 +21,12 @@ describe('ObjectRepository', function(){
             expect(factory.hasCreatedAnObject()).to.equal(true)
         })
 
-        it('must set the id as the one provided by the id generator', async function(){
+        it('must set the id as the one provided by the id generator plus the prefix', async function(){
             var newId = 'newId'
             idGenerator.setFakeId(newId)
             await repository.getNew()
             
-            expect(factory.hasCreatedAnObjectWith({id: newId})).to.equal(true)
+            expect(factory.hasCreatedAnObjectWith({id: `internal-${newId}`})).to.equal(true)
         })
 
         it('must set the state as the given state', async function(){
@@ -52,7 +52,7 @@ describe('ObjectRepository', function(){
             idGenerator.setFakeId(id)
             await repository.getNew()
 
-            expect(state.hasRegistered(id)).to.equal(true)
+            expect(state.hasRegistered(`internal-${id}`)).to.equal(true)
         })
     })
 

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -4,7 +4,8 @@ module.exports = {
   testRunner: "mocha",
   coverageAnalysis: "perTest",
   mochaOptions:{
-    spec: ['domain/*.spec.js']
+    spec: ['domain/*.spec.js',
+      'test-integration/*.spec.js']
   },
   mutate: ['domain/*.js',
     '!domain/*.spec.js',

--- a/test-integration/IntegrationTests.spec.js
+++ b/test-integration/IntegrationTests.spec.js
@@ -9,6 +9,44 @@ describe('Integration tests', function(){
     })
 
     describe('Object repository', function(){
+        it('must allow creating an object with specific id', async function(){
+            var object = await objectRepository.getNew('specific-id')
+            //qué pinta tiene el id que tenemos que utilizar?
+            //porque los ids ahora mismo los están generando el propio repository
+            //tenemos que poder generar objetos con un id específico
+            //podemos marcar esos objetos de modo que nunca coincidan
+            //por ejemplo con un prefijo: custom-<id>
+            //después cuando haga get por id tendría que poder ponerlo sin conocer ese sufijo
+            //quizá necesitemos un nuevo tipo de nodo, un nodo raíz
+            //el objetivo es que al reiniciar, la aplicación pueda volver a referenciar al nodo raíz
+            //application-id: aildfhoq84n48rfhru78n2ourfhr72o3urfheu2o8rfh2o8...(2048 caracteres)
+            //ese id es el que nos permite volver a cargar la aplicación
+            //cómo hacemos para compaginar los dos tipos de ids??
+            //quizá es que no necesitamos el id interno para nada
+            //eso sólo lo utiliza el propio state para enlazar sus elementos
+
+            //entonces si generamos un nuevo objeto con id definido
+            
+
+            //necesitamos poder generar objetos a partir de un identificador
+            //de modo que no colisione con el resto de objetos
+            //podemos usar un prefijo y luego si pedimos un objeto propio con el identificador otra vez
+            //entonces volvermos a añadir el prefijo
+            //y si pedimos un objeto por id normal
+            //entonces no añadimos el prefijo, es decir, que necesitamos otro método para obtener objeto
+            //o que el método que tenemos para obtener objetos por id se el custom
+            //y hacemos un test para comprobar que nunca van a colisionar con los objetos creados internamente
+            
+
+
+            //se podrá tener un id único en el mundo por cada objeto??
+            //de forma que se pudieran compartir objetos específicos
+    
+            expect(await object.get('type')).to.equal('house')
+            expect(await object.get('name')).to.equal('my house')
+            expect(await object.get('color')).to.equal('red')
+        })
+
         it('must allow to assign and read values', async function(){
             var object = await objectRepository.getNew()
             await object.set('type', 'house')


### PR DESCRIPTION
Added a getRoot method to get or create a new object with a specific id
The object id will not collide with any other internal object id